### PR TITLE
Argument to localize the payment button

### DIFF
--- a/paypal-digital-goods.class.php
+++ b/paypal-digital-goods.class.php
@@ -286,7 +286,8 @@ abstract class PayPal_Digital_Goods {
 							'type'      => 'anchor',
 							'href'      => PayPal_Digital_Goods_Configuration::checkout_url(),
 							'alt'       => 'Submit',
-							'get_token' => true
+							'get_token' => true,
+							'locale'    => 'en_US'
 					);
 
 		$args = array_merge( $defaults, $args );
@@ -299,9 +300,9 @@ abstract class PayPal_Digital_Goods {
 			if( $args['href'] == PayPal_Digital_Goods_Configuration::checkout_url() )
 				$args['href'] .= $this->token;
 
-			$button = '<a href="' . $args['href'] . '" id="' . $args['id'] . '" alt="' . $args['alt'] . '"><img src="https://www.paypal.com/en_US/i/btn/btn_dg_pay_w_paypal.gif" border="0" /></a>';
+			$button = '<a href="' . $args['href'] . '" id="' . $args['id'] . '" alt="' . $args['alt'] . '"><img src="https://www.paypal.com/' . $args['locale'] . '/i/btn/btn_dg_pay_w_paypal.gif" border="0" /></a>';
 		} else {
-			$button = '<input type="image" id="' . $args['id'] . '" alt="' . $args['alt'] . '" src="https://www.paypal.com/en_US/i/btn/btn_dg_pay_w_paypal.gif">';
+			$button = '<input type="image" id="' . $args['id'] . '" alt="' . $args['alt'] . '" src="https://www.paypal.com/' . $args['locale'] . '/i/btn/btn_dg_pay_w_paypal.gif">';
 		}
 
 		return $button;


### PR DESCRIPTION
This adds a new argument to ::get_buy_button() so that we can have localized buttons. Just pass a 'locale' argument:

```
$button = $paypalPurchase->get_buy_button(array('locale' => 'fr_FR'));
echo $paypalPurchase->print_buy_button(array('locale' => 'es_ES'));
```
