### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ PayPal_Digital_Goods_Configuration::signature( 'PAYPAL_API_SIGNATURE' );
 
 PayPal_Digital_Goods_Configuration::return_url( 'http://example.com/return.php?paypal=paid' );
 PayPal_Digital_Goods_Configuration::cancel_url( 'http://example.com/return.php?paypal=cancel' );
+PayPal_Digital_Goods_Configuration::notify_url( 'http://example.com/return.php?paypal=notify' );
 
 PayPal_Digital_Goods_Configuration::currency( 'USD' ); // 3 char character code, must be one of the values here: https://developer.paypal.com/docs/classic/api/currency_codes/
 ?>


### PR DESCRIPTION
It seems paypal now requires the notify url to be set or an error will be returned. Added this line so the example configuration will work without issue.
