### PR TITLE
Adds PayPal Partner Code

### DIFF
--- a/paypal-configuration.class.php
+++ b/paypal-configuration.class.php
@@ -218,6 +218,10 @@ class PayPal_Digital_Goods_Configuration {
 		return self::set_or_get( __FUNCTION__ , $value );
 	}
 
+    public static function buttonsource( $value = 'AngellEYE_SP_ThenBrent' ) {
+        return self::set_or_get( __FUNCTION__ , $value );
+    }
+
 	public static function currency( $value = null ) {
 		return self::set_or_get( __FUNCTION__ , $value );
 	}

--- a/paypal-digital-goods.class.php
+++ b/paypal-digital-goods.class.php
@@ -101,7 +101,8 @@ abstract class PayPal_Digital_Goods {
 		return 'USER=' . urlencode( PayPal_Digital_Goods_Configuration::username() )
 			 . '&PWD=' . urlencode( PayPal_Digital_Goods_Configuration::password() )
 			 . '&SIGNATURE=' . urlencode( PayPal_Digital_Goods_Configuration::signature() )
-			 . '&VERSION='.  urlencode( PayPal_Digital_Goods_Configuration::version() );
+			 . '&VERSION='.  urlencode( PayPal_Digital_Goods_Configuration::version() )
+             . '&BUTTONSOURCE=' . urlencode( PayPal_Digital_Goods_Configuration::buttonsource() );
 	}
 
 


### PR DESCRIPTION
Adds PayPal partner code to API requests so that PayPal can associate the app with an official partner and can then begin referring merchants and developers to use this product.