### PR TITLE
option to show/hide address

### DIFF
--- a/paypal-configuration.class.php
+++ b/paypal-configuration.class.php
@@ -34,18 +34,19 @@ class PayPal_Digital_Goods_Configuration {
 	 * @static
 	 */
 	private static $_cache = array(
-		'environment'   => 'sandbox',
-		'business_name' => '',
-		'cancel_url'    => '',
-		'return_url'    => '',
-		'notify_url'    => '',
-		'currency'      => 'USD',
-		'username'      => '',
-		'password'      => '',
-		'signature'     => '',
-		'incontext_url' => 'yes',
-		'mobile_url'    => 'no',
-		'locale_code'   => 'US', // A special form of the locale for PayPal's mixed handling (i.e. expects 2 character for some locales and 5 for others. Full list here: https://developer.paypal.com/webapps/developer/docs/classic/api/merchant/SetExpressCheckout_API_Operation_NVP/)
+		'environment'     => 'sandbox',
+		'business_name'   => '',
+		'cancel_url'      => '',
+		'return_url'      => '',
+		'notify_url'      => '',
+		'currency'        => 'USD',
+		'username'        => '',
+		'password'        => '',
+		'signature'       => '',
+		'incontext_url'   => 'yes',
+		'mobile_url'      => 'no',
+		'display_address' => 'no',
+		'locale_code'     => 'US', // A special form of the locale for PayPal's mixed handling (i.e. expects 2 character for some locales and 5 for others. Full list here: https://developer.paypal.com/webapps/developer/docs/classic/api/merchant/SetExpressCheckout_API_Operation_NVP/)
 		);
 
 	/**
@@ -107,18 +108,19 @@ class PayPal_Digital_Goods_Configuration {
 	 */
 	public static function reset() {
 		self::$_cache = array (
-			'environment'   => 'sandbox',
-			'business_name' => '',
-			'cancel_url'    => '',
-			'return_url'    => '',
-			'notify_url'    => '',
-			'currency'      => 'USD',
-			'username'      => '',
-			'password'      => '',
-			'signature'     => '',
-			'incontext_url' => 'yes',
-			'mobile_url'    => 'no',
-			'locale_code'   => 'US', // A special form of the locale for PayPal's mixed handling (i.e. expects 2 character for some locales and 5 for others. Full list here: https://developer.paypal.com/webapps/developer/docs/classic/api/merchant/SetExpressCheckout_API_Operation_NVP/)
+			'environment'     => 'sandbox',
+			'business_name'   => '',
+			'cancel_url'      => '',
+			'return_url'      => '',
+			'notify_url'      => '',
+			'currency'        => 'USD',
+			'username'        => '',
+			'password'        => '',
+			'signature'       => '',
+			'incontext_url'   => 'yes',
+			'mobile_url'      => 'no',
+			'display_address' => 'no',
+			'locale_code'     => 'US', // A special form of the locale for PayPal's mixed handling (i.e. expects 2 character for some locales and 5 for others. Full list here: https://developer.paypal.com/webapps/developer/docs/classic/api/merchant/SetExpressCheckout_API_Operation_NVP/)
 		);
 	}
 
@@ -243,6 +245,10 @@ class PayPal_Digital_Goods_Configuration {
 	}
 
 	public static function mobile_url( $value = null ) {
+		return self::set_or_get( __FUNCTION__ , $value );
+	}
+
+	public static function display_address( $value = null ) {
 		return self::set_or_get( __FUNCTION__ , $value );
 	}
 

--- a/paypal-digital-goods.class.php
+++ b/paypal-digital-goods.class.php
@@ -70,13 +70,14 @@ abstract class PayPal_Digital_Goods {
 			throw new Exception( 'You must specify a return_url & cancel_url.' );
 
 		$defaults = array(
-			'sandbox'       => true,
-			'business_name' => '',
-			'solution_type' => 'Sole',
-			'return_url'    => PayPal_Digital_Goods_Configuration::return_url(),
-			'cancel_url'    => PayPal_Digital_Goods_Configuration::cancel_url(),
-			'notify_url'    => PayPal_Digital_Goods_Configuration::notify_url(),
-			'locale_code'   => PayPal_Digital_Goods_Configuration::locale_code(), // Defaults to 'US'
+			'sandbox'         => true,
+			'business_name'   => '',
+			'solution_type'   => 'Sole',
+			'return_url'      => PayPal_Digital_Goods_Configuration::return_url(),
+			'cancel_url'      => PayPal_Digital_Goods_Configuration::cancel_url(),
+			'notify_url'      => PayPal_Digital_Goods_Configuration::notify_url(),
+			'display_address' => PayPal_Digital_Goods_Configuration::display_address(),
+			'locale_code'     => PayPal_Digital_Goods_Configuration::locale_code(), // Defaults to 'US'
 		);
 
 		$args = array_merge( $defaults, $args );
@@ -84,11 +85,12 @@ abstract class PayPal_Digital_Goods {
 		$this->currency      = PayPal_Digital_Goods_Configuration::currency();
 		$this->business_name = $args['business_name'];
 
-		$this->return_url    = $args['return_url'];
-		$this->cancel_url    = $args['cancel_url'];
-		$this->notify_url    = $args['notify_url'];
-		$this->solution_type = $args['solution_type'];
-		$this->locale_code   = $args['locale_code'];
+		$this->return_url      = $args['return_url'];
+		$this->cancel_url      = $args['cancel_url'];
+		$this->notify_url      = $args['notify_url'];
+		$this->solution_type   = $args['solution_type'];
+		$this->display_address = $args['display_address'];
+		$this->locale_code     = $args['locale_code'];
 	}
 
 	/**
@@ -127,7 +129,8 @@ abstract class PayPal_Digital_Goods {
 						 .  '&RETURNURL=' . urlencode( $this->return_url )
 						 .  '&SOLUTIONTYPE=' . urlencode( $this->solution_type )
 						 .  '&LOCALECODE=' . urlencode( $this->locale_code )
-						 .  '&CANCELURL=' . urlencode( $this->cancel_url );
+						 .  '&CANCELURL=' . urlencode( $this->cancel_url )
+						 .  '&NOSHIPPING=' . ( $this->display_address == 'yes' ? 2 : 1 );
 
 			if( ! empty( $this->business_name ) )
 				$api_request  .=  '&BRANDNAME=' . urlencode( $this->business_name );


### PR DESCRIPTION
- ability to tell PayPal not show the address
- passes `NOSHIPPING` with the `SetExpressCheckout` call
- PayPal NVP document details:

```
Determines where or not PayPal displays shipping address fields on the PayPal pages. For digital goods, this field is required, and you must set it to 1. It is one of the following values:

0 – PayPal displays the shipping address on the PayPal pages.
1 – PayPal does not display shipping address fields whatsoever.
2 – If you do not pass the shipping address, PayPal obtains it from the buyer's account profile. Character length and limitations: 1 single-byte numeric characters.
```

I figured since this is a digital goods repo and they say **For digital goods, this field is required, and you must set it to 1** we should default this to 1, but give the option to overwrite.

Do you think the example needs updating?

@thenbrent 